### PR TITLE
Add jellybeans color theme.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,4 @@
+# Contributors
+
+ * [Darren Cheng](https://github.com/darrenli) - jellybeans theme
+

--- a/autoload/tmuxline/themes/jellybeans.vim
+++ b/autoload/tmuxline/themes/jellybeans.vim
@@ -1,0 +1,16 @@
+"
+" For use with the lightline.vim jellybeans statusline theme.
+"
+function! tmuxline#themes#jellybeans#get()
+  return {
+\   'bg'   : [ 244, 236 ],
+\   'a'    : [ 236, 103 ],
+\   'b'    : [ 253, 239 ],
+\   'c'    : [ 244, 236 ],
+\   'win'  : [ 103, 236 ],
+\   'cwin' : [ 236, 103 ],
+\   'x'    : [ 244, 236 ],
+\   'y'    : [ 253, 239 ],
+\   'z'    : [ 236, 103 ]
+\ }
+endfunc


### PR DESCRIPTION
@edkolev - Thanks for this project. I'm pretty happy with how my tmux statusline looks right now!

Anyway, I added a color scheme to use with the [lightline.vim](https://github.com/itchyny/lightline.vim) version of the jellybeans vim statusline. I thought it might be useful to someone else, hence the pull.

Here's what it looks like:
![screen shot 2014-01-19 at 7 33 53 pm](https://f.cloud.github.com/assets/885841/1951567/b0c37ab2-8184-11e3-829a-7f6545aa062c.png)

I didn't look to hard, but I couldn't find an easy way to add a new colors scheme without modifying the plugin code. It might make sense to be able to specify a custom theme hash with a `let g:tmuxline_custom_theme = { ... }`.
