### PR TITLE
Suppress error message when setting status-utf8

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -191,7 +191,11 @@ fun! tmuxline#get_global_config(line, theme)
 
   let global_config = []
   for [tmux_option, value] in items(misc_options)
-    let global_config += [ 'set -g ' . tmux_option . ' ' . tmuxline#util#wrap_in_quotes(value) ]
+    if tmux_option == 'status-utf8'
+      let global_config += [ 'set -gq ' . tmux_option . ' ' . tmuxline#util#wrap_in_quotes(value) ]
+    else
+      let global_config += [ 'set -g ' . tmux_option . ' ' . tmuxline#util#wrap_in_quotes(value) ]
+    endif
   endfor
   for [tmux_option, value] in items(win_options)
     let global_config += [ 'setw -g ' . tmux_option . ' ' . tmuxline#util#wrap_in_quotes(value) ]


### PR DESCRIPTION
Fixes #53. If you’re using a tmuxline.conf snapshot file, you’ll have to recreate it.
