### PR TITLE
TmuxlineSnapshot: add output to current buffer if file is "-"

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -96,13 +96,24 @@ fun! tmuxline#apply(line_settings) abort
 endfun
 
 fun! tmuxline#snapshot(file, overwrite) abort
-  let file = fnamemodify(a:file, ":p")
-  let dir = fnamemodify(file, ':h')
-
   if (len(s:snapshot) == 0)
     echohl ErrorMsg | echomsg ":Tmuxline should be executed before :TmuxlineSnapshot" | echohl None
     return
   endif
+
+  let lines = []
+  let lines += [ '# This tmux statusbar config was created by tmuxline.vim']
+  let lines += [ '# on ' . strftime("%a, %d %b %Y") ]
+  let lines += [ '' ]
+  let lines += s:snapshot
+
+  if (a:file == "-")
+      put =lines
+      return
+  endif
+
+  let file = fnamemodify(a:file, ":p")
+  let dir = fnamemodify(file, ':h')
 
   if empty(file)
     throw "Bad file name: \"" . file . "\""
@@ -112,12 +123,6 @@ fun! tmuxline#snapshot(file, overwrite) abort
     echohl ErrorMsg | echomsg "File exists (add ! to override)" | echohl None
     return
   endif
-
-  let lines = []
-  let lines += [ '# This tmux statusbar config was created by tmuxline.vim']
-  let lines += [ '# on ' . strftime("%a, %d %b %Y") ]
-  let lines += [ '' ]
-  let lines += s:snapshot
 
   call writefile(lines, file)
 endfun

--- a/doc/tmuxline.txt
+++ b/doc/tmuxline.txt
@@ -30,6 +30,9 @@ Commands will be available if vim is inside tmux and tmux is in PATH
   after |tmuxline| has set tmux's statusline, i.e. after executing
   |:Tmuxline|. The file will not be overwritten unless bang [!] is given.
 
+  If the argument is "-", the snapshot configuration will be inserted to the
+  current buffer beneath the cursor rather than written to an actual file.
+
 ==============================================================================
 CONFIGURATION                                       *tmuxline-configuration*
 


### PR DESCRIPTION
Rather than save my tmuxline config snapshot in a separate file, I'd prefer to just dump the config directly into the bottom of my tmux.conf.  To ease that, I tweaked the `:TmuxlineSnapshot` command to put the text into the current buffer isntead of a file if the argument given is `-`.

To implement this, I had to move the snapgeneration up first in the function, then check for a `-` file, and then do real file handling after that.