### PR TITLE
Expose configuration for statusbar window list justification

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -4,6 +4,7 @@
 
 let s:default_theme = 'powerline'
 let s:default_preset = 'powerline'
+let s:default_status_justify = 'centre'
 
 let s:powerline_separators = {
     \ 'left' : '',
@@ -147,6 +148,7 @@ fun! tmuxline#get_global_config(line, theme)
   let message_fg         = tmuxline#util#normalize_color(a:theme.cwin[0])
   let pane_border        = has_key(a:theme, 'pane',) ? tmuxline#util#normalize_color(a:theme.pane[0]) : tmuxline#util#normalize_color(a:theme.b[1])
   let pane_active_border = has_key(a:theme, 'cpane',) ? tmuxline#util#normalize_color(a:theme.cpane[0]) : tmuxline#util#normalize_color(a:theme.a[1])
+  let status_justify     = get(g:, 'tmuxline_status_justify', s:default_status_justify)
 
   let window = tmuxline#util#get_color_definition_from_theme('win', a:theme)
   let window_fg = window[0]
@@ -169,7 +171,7 @@ fun! tmuxline#get_global_config(line, theme)
         \ 'message-command-bg'          : message_bg,
         \ 'pane-border-fg'              : pane_border,
         \ 'pane-active-border-fg'       : pane_active_border,
-        \ 'status-justify'               : 'centre',
+        \ 'status-justify'               : status_justify,
         \ 'status-left-length'           : 100,
         \ 'status-right-length'          : 100,
         \ 'status'                       : 'on',

--- a/doc/tmuxline.txt
+++ b/doc/tmuxline.txt
@@ -34,7 +34,7 @@ Commands will be available if vim is inside tmux and tmux is in PATH
 CONFIGURATION                                       *tmuxline-configuration*
 
 * enable/disable usage of powerline symbols for separators (default on) >
-  g:tmuxline_powerline_separators = 0
+  let g:tmuxline_powerline_separators = 0
 <
 * configure the preset used in the statusline. Can be a "string" holding the
   name of the preset, or a hash {} holding fine-tuned configuration. The hash
@@ -78,6 +78,11 @@ CONFIGURATION                                       *tmuxline-configuration*
       \ 'right' : '',
       \ 'right_alt' : '<',
       \ 'space' : ' '}
+<
+* configure the alignment of the tmux window list; maps to the tmux command
+  'set -g status-justify'. Values are 'left', 'centre', or 'right'
+  Default is 'centre' >
+  let g:tmuxline_status_justify = 'left'
 <
 ==============================================================================
 API                                                           *tmuxline-api*


### PR DESCRIPTION
Set g:tmuxline_status_justify to override the default behavior of
'tmux set -g status-justify centre'
