### PR TITLE
Remove `status-utf8` from `misc_options`

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -175,8 +175,7 @@ fun! tmuxline#get_global_config(line, theme)
         \ 'status'                       : 'on',
         \ 'status-right-attr'           : 'none',
         \ 'status-left-attr'            : 'none',
-        \ 'status-attr'                 : 'none',
-        \ 'status-utf8'                  : 'on'}
+        \ 'status-attr'                 : 'none'}
   let win_options = {
         \ 'window-status-fg'            : window_fg,
         \ 'window-status-bg'            : window_bg,


### PR DESCRIPTION
The `status-utf8` option in no longer needed since version `1` of tmux, and including it results in an `unknown option: status-utf8` notice every time tmux is started.