### PR TITLE
Remove status-utf8 option

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -214,8 +214,7 @@ fun! tmuxline#get_global_config(line, theme)
         \ 'status'                       : 'on',
         \ 'status-right-attr'           : 'none',
         \ 'status-left-attr'            : 'none',
-        \ 'status-attr'                 : 'none',
-        \ 'status-utf8'                  : 'on'}
+        \ 'status-attr'                 : 'none'}
   let win_options = {
         \ 'window-status-fg'            : window_fg,
         \ 'window-status-bg'            : window_bg,


### PR DESCRIPTION
This option has been removed from the latest versions of tmux, and will
cause an [annoying error message for users on
startup](https://github.com/tmux/tmux/issues/230)

See #72