### PR TITLE
Change: remove utf8 option

### DIFF
--- a/autoload/tmuxline.vim
+++ b/autoload/tmuxline.vim
@@ -216,8 +216,7 @@ fun! tmuxline#get_global_config(line, theme)
         \ 'status'                       : 'on',
         \ 'status-right-attr'           : 'none',
         \ 'status-left-attr'            : 'none',
-        \ 'status-attr'                 : 'none',
-        \ 'status-utf8'                  : 'on'}
+        \ 'status-attr'                 : 'none'}
   let win_options = {
         \ 'window-status-fg'            : window_fg,
         \ 'window-status-bg'            : window_bg,


### PR DESCRIPTION
This is the default and now an unsupported option as of tmux 2.2

https://github.com/tmux/tmux/blob/336beeb09afcc8f381062da49a4c23c6d16a9833/CHANGES#L256-L262