### PR TITLE
util: added 24bit support for create_theme_from_airline

### DIFF
--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -179,16 +179,29 @@ fun! tmuxline#util#create_theme_from_lightline(mode_palette)
 endfun
 
 fun! tmuxline#util#create_theme_from_airline(mode_palette)
-  let theme = {
-        \'a'    : a:mode_palette.airline_a[2:4],
-        \'b'    : a:mode_palette.airline_b[2:4],
-        \'c'    : a:mode_palette.airline_c[2:4],
-        \'x'    : a:mode_palette.airline_x[2:4],
-        \'y'    : a:mode_palette.airline_y[2:4],
-        \'z'    : a:mode_palette.airline_z[2:4],
-        \'bg'   : a:mode_palette.airline_c[2:4],
-        \'cwin' : a:mode_palette.airline_b[2:4],
-        \'win'  : a:mode_palette.airline_c[2:4]}
+  if &termguicolors
+    let theme = {
+          \'a'    : a:mode_palette.airline_a[0:1] + [a:mode_palette.airline_a[4]],
+          \'b'    : a:mode_palette.airline_b[0:1] + [a:mode_palette.airline_b[4]],
+          \'c'    : a:mode_palette.airline_c[0:1] + [a:mode_palette.airline_c[4]],
+          \'x'    : a:mode_palette.airline_x[0:1] + [a:mode_palette.airline_x[4]],
+          \'y'    : a:mode_palette.airline_y[0:1] + [a:mode_palette.airline_y[4]],
+          \'z'    : a:mode_palette.airline_z[0:1] + [a:mode_palette.airline_z[4]],
+          \'bg'   : a:mode_palette.airline_c[0:1] + [a:mode_palette.airline_c[4]],
+          \'cwin' : a:mode_palette.airline_b[0:1] + [a:mode_palette.airline_b[4]],
+          \'win'  : a:mode_palette.airline_c[0:1] + [a:mode_palette.airline_c[4]]}
+  else
+    let theme = {
+          \'a'    : a:mode_palette.airline_a[2:4],
+          \'b'    : a:mode_palette.airline_b[2:4],
+          \'c'    : a:mode_palette.airline_c[2:4],
+          \'x'    : a:mode_palette.airline_x[2:4],
+          \'y'    : a:mode_palette.airline_y[2:4],
+          \'z'    : a:mode_palette.airline_z[2:4],
+          \'bg'   : a:mode_palette.airline_c[2:4],
+          \'cwin' : a:mode_palette.airline_b[2:4],
+          \'win'  : a:mode_palette.airline_c[2:4]}
+  endif
   call tmuxline#util#try_guess_activity_color( theme )
   return theme
 endfun


### PR DESCRIPTION
I use the 24bit colour space with my vim/airline/tmux setup so I have added 24bit support to tmuxline for the airline theme. This addresses incorrect colours due to the reduced colour space.

Not sure what your thoughts on this are, but I thought I would submit this as a PR for other 24bit users.