### PR TITLE
Add termguicolors support for airline

### DIFF
--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -179,16 +179,29 @@ fun! tmuxline#util#create_theme_from_lightline(mode_palette)
 endfun
 
 fun! tmuxline#util#create_theme_from_airline(mode_palette)
-  let theme = {
-        \'a'    : a:mode_palette.airline_a[2:4],
-        \'b'    : a:mode_palette.airline_b[2:4],
-        \'c'    : a:mode_palette.airline_c[2:4],
-        \'x'    : a:mode_palette.airline_x[2:4],
-        \'y'    : a:mode_palette.airline_y[2:4],
-        \'z'    : a:mode_palette.airline_z[2:4],
-        \'bg'   : a:mode_palette.airline_c[2:4],
-        \'cwin' : a:mode_palette.airline_b[2:4],
-        \'win'  : a:mode_palette.airline_c[2:4]}
+  if &termguicolors
+    let theme = {
+          \'a'    : [a:mode_palette.airline_a[0], a:mode_palette.airline_a[1], a:mode_palette.airline_a[4]],
+          \'b'    : [a:mode_palette.airline_b[0], a:mode_palette.airline_b[1], a:mode_palette.airline_b[4]],
+          \'c'    : [a:mode_palette.airline_c[0], a:mode_palette.airline_c[1], a:mode_palette.airline_c[4]],
+          \'x'    : [a:mode_palette.airline_x[0], a:mode_palette.airline_x[1], a:mode_palette.airline_x[4]],
+          \'y'    : [a:mode_palette.airline_y[0], a:mode_palette.airline_y[1], a:mode_palette.airline_y[4]],
+          \'z'    : [a:mode_palette.airline_z[0], a:mode_palette.airline_z[1], a:mode_palette.airline_z[4]],
+          \'bg'   : [a:mode_palette.airline_c[0], a:mode_palette.airline_c[1], a:mode_palette.airline_c[4]],
+          \'cwin' : [a:mode_palette.airline_b[0], a:mode_palette.airline_b[1], a:mode_palette.airline_b[4]],
+          \'win'  : [a:mode_palette.airline_c[0], a:mode_palette.airline_c[1], a:mode_palette.airline_c[4]]}
+  else
+    let theme = {
+          \'a'    : a:mode_palette.airline_a[2:4],
+          \'b'    : a:mode_palette.airline_b[2:4],
+          \'c'    : a:mode_palette.airline_c[2:4],
+          \'x'    : a:mode_palette.airline_x[2:4],
+          \'y'    : a:mode_palette.airline_y[2:4],
+          \'z'    : a:mode_palette.airline_z[2:4],
+          \'bg'   : a:mode_palette.airline_c[2:4],
+          \'cwin' : a:mode_palette.airline_b[2:4],
+          \'win'  : a:mode_palette.airline_c[2:4]}
+  endif
   call tmuxline#util#try_guess_activity_color( theme )
   return theme
 endfun


### PR DESCRIPTION
tmuxline only gets cterm values even if `termguicolors` is set.
The update checks if `termguicolors` is set and then creates a theme dictionary with true color entries from the airline theme. Else, the previous implementation for the theme dictionary is used.