### PR TITLE
Fix usage on non-termguicolors enabled vim

### DIFF
--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -179,7 +179,7 @@ fun! tmuxline#util#create_theme_from_lightline(mode_palette)
 endfun
 
 fun! tmuxline#util#create_theme_from_airline(mode_palette)
-  if &termguicolors
+  if exists("+termguicolors") && &termguicolors
     let theme = {
           \'a'    : [a:mode_palette.airline_a[0], a:mode_palette.airline_a[1], a:mode_palette.airline_a[4]],
           \'b'    : [a:mode_palette.airline_b[0], a:mode_palette.airline_b[1], a:mode_palette.airline_b[4]],


### PR DESCRIPTION
PR #93 introduced support for `termguicolors`.

Unfortunately the check for `termguicolors` is executed even if vim has been compiled without `termguicolors` support (which is the case for example for vim on Ubuntu 16.04 Xenial LTS), resulting in:

```
E113: Unknown option: termguicolors
E15: Invalid expression: &termguicolors
```

This patch fixes the shortcoming by checking for the existence of
`termguicolors` first.