### PR TITLE
Add termguicolors support for lightline

### DIFF
--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -163,18 +163,25 @@ fun! tmuxline#util#get_colors_from_vim_statusline() abort
         \'reversed_statusline_nc' : [ stl_nc_bg, stl_nc_fg, stl_nc_attr ]}
 endfun
 
+fun! tmuxline#util#create_theme_from_lightline_help(arr)
+    if len(a:arr)==5
+        return a:arr[4]
+    else
+        return ''
+    endif
+endfun
 fun! tmuxline#util#create_theme_from_lightline(mode_palette)
   if exists("+termguicolors") && &termguicolors
     let theme = {
-          \'a' : a:mode_palette.left[s:FG][0:1],
-          \'b' : a:mode_palette.left[s:BG][0:1],
-          \'c' : a:mode_palette.middle[s:FG][0:1],
-          \'x' : a:mode_palette.middle[s:FG][0:1],
-          \'y' : a:mode_palette.right[s:BG][0:1],
-          \'z' : a:mode_palette.right[s:FG][0:1],
-          \'bg' : a:mode_palette.middle[s:FG][0:1],
-          \'cwin' : a:mode_palette.left[s:BG][0:1],
-          \'win' : a:mode_palette.middle[s:FG][0:1]}
+          \'a' : [a:mode_palette.left[s:FG][0], a:mode_palette.left[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.left[s:FG])],
+          \'b' : [a:mode_palette.left[s:BG][0], a:mode_palette.left[s:BG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.left[s:BG])],
+          \'c' : [a:mode_palette.middle[s:FG][0], a:mode_palette.middle[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.middle[s:FG])],
+          \'x' : [a:mode_palette.middle[s:FG][0], a:mode_palette.middle[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.middle[s:FG])],
+          \'y' : [a:mode_palette.right[s:BG][0], a:mode_palette.right[s:BG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.right[s:BG])],
+          \'z' : [a:mode_palette.right[s:FG][0], a:mode_palette.right[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.right[s:FG])],
+          \'bg' : [a:mode_palette.middle[s:FG][0], a:mode_palette.middle[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.middle[s:FG])],
+          \'cwin' : [a:mode_palette.left[s:BG][0], a:mode_palette.left[s:BG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.left[s:BG])],
+          \'win' : [a:mode_palette.middle[s:FG][0], a:mode_palette.middle[s:FG][1], tmuxline#util#create_theme_from_lightline_help(a:mode_palette.middle[s:FG])]}
   else
     let theme = {
           \'a' : a:mode_palette.left[s:FG][2:4],

--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -164,16 +164,29 @@ fun! tmuxline#util#get_colors_from_vim_statusline() abort
 endfun
 
 fun! tmuxline#util#create_theme_from_lightline(mode_palette)
-  let theme = {
-        \'a' : a:mode_palette.left[s:FG][2:4],
-        \'b' : a:mode_palette.left[s:BG][2:4],
-        \'c' : a:mode_palette.middle[s:FG][2:4],
-        \'x' : a:mode_palette.middle[s:FG][2:4],
-        \'y' : a:mode_palette.right[s:BG][2:4],
-        \'z' : a:mode_palette.right[s:FG][2:4],
-        \'bg' : a:mode_palette.middle[s:FG][2:4],
-        \'cwin' : a:mode_palette.left[s:BG][2:4],
-        \'win' : a:mode_palette.middle[s:FG][2:4]}
+  if exists("+termguicolors") && &termguicolors
+    let theme = {
+          \'a' : a:mode_palette.left[s:FG][0:1],
+          \'b' : a:mode_palette.left[s:BG][0:1],
+          \'c' : a:mode_palette.middle[s:FG][0:1],
+          \'x' : a:mode_palette.middle[s:FG][0:1],
+          \'y' : a:mode_palette.right[s:BG][0:1],
+          \'z' : a:mode_palette.right[s:FG][0:1],
+          \'bg' : a:mode_palette.middle[s:FG][0:1],
+          \'cwin' : a:mode_palette.left[s:BG][0:1],
+          \'win' : a:mode_palette.middle[s:FG][0:1]}
+  else
+    let theme = {
+          \'a' : a:mode_palette.left[s:FG][2:4],
+          \'b' : a:mode_palette.left[s:BG][2:4],
+          \'c' : a:mode_palette.middle[s:FG][2:4],
+          \'x' : a:mode_palette.middle[s:FG][2:4],
+          \'y' : a:mode_palette.right[s:BG][2:4],
+          \'z' : a:mode_palette.right[s:FG][2:4],
+          \'bg' : a:mode_palette.middle[s:FG][2:4],
+          \'cwin' : a:mode_palette.left[s:BG][2:4],
+          \'win' : a:mode_palette.middle[s:FG][2:4]}
+  endif
   call tmuxline#util#try_guess_activity_color( theme )
   return theme
 endfun


### PR DESCRIPTION
Just like [#93](https://github.com/edkolev/tmuxline.vim/pull/93), this PR check if `termguicolors` is set, and then create a color scheme use true colors.