### PR TITLE
Allow more control over local presets

### DIFF
--- a/autoload/tmuxline/util.vim
+++ b/autoload/tmuxline/util.vim
@@ -83,7 +83,11 @@ fun! tmuxline#util#load_line_from_preset(preset_name) abort
   try
     let line = tmuxline#presets#{a:preset_name}#get()
   catch /^Vim(let):E117: Unknown function: tmuxline#presets#.*#get/
-    throw "tmuxline: Preset cannot be found '" . a:preset_name . "'"
+    try
+      let line = {a:preset_name}()
+    catch /^Vim(let):E117: Unknown function: .*/
+      throw "tmuxline: Preset cannot be found '" . a:preset_name . "'"
+    endtry
   endtry
   return line
 endfun


### PR DESCRIPTION
Allow presets to be defined locally without using
tmuxline#util#create_line_from_hash, so as to have more control over the
preset.

This is done by looking for the specified preset string as a local function
as well.